### PR TITLE
Resolves #7 Support wildcard

### DIFF
--- a/simple_acme_dns/__init__.py
+++ b/simple_acme_dns/__init__.py
@@ -502,11 +502,11 @@ class ACMEClient:
             # Loop through each domain being verified
             for domain, token, resolver in resolvers:
                 # Only try to verify the domain if it has not already been verified
-                if domain not in verified:
+                if token not in verified:
                     resolver.resolve()
                     # Save this domain as verified if our token was found in the TXT record values
                     if token in resolver.values:
-                        verified.append(domain)
+                        verified.append(token)
                     # If verbose mode is enabled, print the results to the console
                     if verbose:
                         msg = "Token '{token}' for '{domain}' {action} in {values} via {ns}".format(
@@ -598,6 +598,9 @@ class ACMEClient:
             msg = "Domains must be rtype 'list'."
             raise errors.InvalidDomain(msg)
         for domain in self.domains:
+            if domain[:2] == "*.":
+                # If wildcard domain, strip of the wildcard to validate domain
+                domain = domain[2:]
             if not validators.domain(domain):
                 msg = "Invalid domain name '{domain}'. Domain name must adhere to RFC2181.".format(domain=domain)
                 raise errors.InvalidDomain(msg)


### PR DESCRIPTION
Resolves #7

There are only 2 things that need to be addressed to support wildcard certs:

1.) https://github.com/jaredhendrickson13/simple_acme_dns/blob/master/simple_acme_dns/__init__.py#L600-L603
If it is a wildcard cert, validators will always fail.  You would have to strip of the "*." in the front and validate the rest.

2.)  ACMEClient.check_dns_propagation needs to be rewritten to support multiple of the same domain. If you are referencing both "*.domain.com" and "domain.com" on the same request, you will get 2 challenge domains of _acme-challenge.domain.com.  
https://github.com/jaredhendrickson13/simple_acme_dns/blob/master/simple_acme_dns/__init__.py#L505
This means that when the second domain is already in 'verified' here, it will skip adding it. 
This means that https://github.com/jaredhendrickson13/simple_acme_dns/blob/master/simple_acme_dns/__init__.py#L522 will always fail.
To resolve this, just keep track of the tokens, not the domains.