### PR TITLE
ci: have Dependabot keep GitHub Actions up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
       interval: "monthly"
     reviewers:
       - "jaredhendrickson13"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
- Has Dependabot monitor and update GitHub Actions dependencies. This currently fixes a couple workflows that are broken due to deprecated Actions dependencies.