### PR TITLE
ci: use pebble for testing

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -48,7 +48,18 @@ jobs:
           python3 -m pip install .
           python3 -m pip install -r requirements-dev.txt
 
+      - name: Install Docker Compose
+        run: |
+          curl -L "https://github.com/docker/compose/releases/download/$(curl -s https://api.github.com/repos/docker/compose/releases/latest | jq -r '.tag_name')/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          chmod +x /usr/local/bin/docker-compose
+          docker-compose --version
+
+      - name: Start Pebble server
+        run: docker-compose -f simple_acme_dns/tests/docker-compose.yml up -d
+
       - name: Test simple_acme_dns package to ensure 100% coverage
+        env:
+          ACME_DIRECTORY: 'https://localhost:14000/dir'
         run: |
           python3 -m coverage run --module unittest simple_acme_dns/tests/test_*
           python3 -m coverage report --show-missing --fail-under 100

--- a/.pylintrc
+++ b/.pylintrc
@@ -433,7 +433,7 @@ exclude-too-few-public-methods=
 ignored-parents=
 
 # Maximum number of arguments for function / method.
-max-args=7
+max-args=8
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=22

--- a/simple_acme_dns/tests/docker-compose.yml
+++ b/simple_acme_dns/tests/docker-compose.yml
@@ -1,0 +1,27 @@
+# Docker compose file for setting up a Pebble ACME and challenge server for testing
+version: "3"
+services:
+  pebble:
+    image: ghcr.io/letsencrypt/pebble:latest
+    command: -config test/config/pebble-config.json -strict -dnsserver 1.1.1.1:53
+    ports:
+      - '14000:14000' # HTTPS ACME API
+      - '15000:15000' # HTTPS Management API
+    networks:
+      acmenet:
+        ipv4_address: 10.30.50.2
+  challtestsrv:
+    image: ghcr.io/letsencrypt/pebble-challtestsrv:latest
+    command: -defaultIPv6 "" -defaultIPv4 10.30.50.3
+    ports:
+      - 8055:8055 # HTTP Management API
+    networks:
+      acmenet:
+        ipv4_address: 10.30.50.3
+networks:
+  acmenet:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 10.30.50.0/24


### PR DESCRIPTION
- Adds `verify_ssl` client setting to enable or disable certificate verification when connecting to the ACME server
- Updates tests support any ACME server and disables certificate verification in tests
- Updates CI/CD workflows to use Pebble instead of LE staging server