### PR TITLE
fix: pin josepy to pre 2.0.0 release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 acme~=3.1.0
 validators~=0.34.0
 dnspython~=2.7.0
+josepy>=1.13.0, <2


### PR DESCRIPTION
Fixes an issue where acme is still depending on deprecated josepy resources